### PR TITLE
feat: refactor to not depend on env vars

### DIFF
--- a/src/flowcore/redis-queue.ts
+++ b/src/flowcore/redis-queue.ts
@@ -1,84 +1,53 @@
 import Redis from "ioredis";
-import _ from "lodash";
 
 import FlowcorePredicateException from "../exceptions/predicate-exception";
 
 import { waitForPredicate } from "./wait-for-predicate";
 
-let redis: Redis | null = null;
-
-if (process.env.REDIS_URL) {
-  redis = new Redis(process.env.REDIS_URL);
+export interface RedisPredicateOptions {
+  redisUrl: string;
+  redisEventIdKey: string;
 }
 
-if (!process.env.REDIS_KEY_PATTERN) {
-  console.warn(
-    `REDIS_KEY_PATTERN not set, using "generic:event-queue" as default`,
-  );
-}
+export type RedisQueueWriter = (eventId: string) => Promise<void>;
 
-export const REDIS_EVENT_ID_KEY =
-  process.env.REDIS_KEY_PATTERN ?? "generic:event-queue";
+export type RedisPredicate = (
+  eventId: string | string[],
+  times?: number,
+  delay?: number,
+) => Promise<void>;
 
-export const redisPredicate = async <T>(
-  eventId?: string | string[],
-  fallback?: () => Promise<T>,
-  predicate?: (result: T) => boolean,
-  times = 20,
-  delay = 250,
-) => {
-  if (!redis || !eventId) {
-    if (!fallback) {
-      throw new Error("Redis not available and no fallback provided");
+export function redisPredicateFactory(
+  options: RedisPredicateOptions,
+): RedisPredicate {
+  const redis = new Redis(options.redisUrl);
+  return async (eventId?: string | string[], times = 20, delay = 250) => {
+    if (!eventId || eventId.length === 0) {
+      return;
     }
-
-    console.debug("Redis not available, using fallback");
-
-    return waitForPredicate(
-      fallback,
-      predicate ?? ((result) => !!result),
-      times,
-      delay,
-    ).catch((error) => {
-      throw new FlowcorePredicateException(error.message);
-    });
-  }
-
-  if (eventId instanceof Array) {
+    const eventIds: string[] = Array.isArray(eventId) ? eventId : [eventId];
     return waitForPredicate(
       async () => {
         const loaded = await Promise.all(
-          eventId.map((id) => redis?.get(`${REDIS_EVENT_ID_KEY}:${id}`)),
+          eventIds.map((id) => redis?.get(`${options.redisEventIdKey}:${id}`)),
         );
 
-        return _.every(loaded, (result) => !!result) as unknown as T;
+        return loaded.every((result) => !!result);
       },
-      predicate ?? ((result) => !!result),
+      (result) => !!result,
       times,
       delay,
     ).catch((error) => {
       throw new FlowcorePredicateException(error.message);
     });
-  }
+  };
+}
 
-  return waitForPredicate(
-    async () => {
-      const loaded = await redis?.get(`${REDIS_EVENT_ID_KEY}:${eventId}`);
-
-      return loaded as unknown as T;
-    },
-    predicate ?? ((result) => !!result),
-    times,
-    delay,
-  ).catch((error) => {
-    throw new FlowcorePredicateException(error.message);
-  });
-};
-
-export const writeToQueue = async (eventId: string) => {
-  if (!redis) {
-    return;
-  }
-
-  await redis.set(`${REDIS_EVENT_ID_KEY}:${eventId}`, "1", "EX", "60");
-};
+export function redisQueueWriterFactory(
+  options: RedisPredicateOptions,
+): RedisQueueWriter {
+  const redis = new Redis(options.redisUrl);
+  return async (eventId: string) => {
+    await redis.set(`${options.redisEventIdKey}:${eventId}`, "1", "EX", "60");
+  };
+}


### PR DESCRIPTION
### Usage example

```ts
export const createWebhookSender = webhookFactory({
  webhookBaseUrl: env.FLOWCORE_WEBHOOK_BASEURL,
  apiKey: env.FLOWCORE_WEBHOOK_API_KEY,
  tenant: env.FLOWCORE_TENANT,
  dataCore: env.FLOWCORE_DATACORE,
  redisUrl: env.REDIS_URL,
  redisEventIdKey: env.REDIS_KEY_PATTERN,
  // These options are meant for dev and will send the event directly to the transformer after send
  localTransformBaseUrl: process.env.DEV_LOCAL_TRANSFORMER_BASEURL,
  localTransformSecret: env.FLOWCORE_TRANSFORMER_SECRET,
  // This one will just set the default waitForPredicate on created webhooks
  waitForPredicates: !!process.env.DEV_LOCAL_TRANSFORMER_BASEURL,
})

export const createFilehookSender = filehookFactory({
  webhookBaseUrl: env.FLOWCORE_WEBHOOK_BASEURL,
  apiKey: env.FLOWCORE_WEBHOOK_API_KEY,
  tenant: env.FLOWCORE_TENANT,
  dataCore: env.FLOWCORE_DATACORE,
  redisUrl: env.REDIS_URL,
  redisEventIdKey: env.REDIS_KEY_PATTERN,
})
```
and
```ts
export const sendEventAccountUpdated = createWebhookSender<z.infer<typeof EventAccountUpdatedPayload>>(
  FlowcoreAccount.flowType,
  FlowcoreAccount.eventType.updated,
)
```